### PR TITLE
added library version and install target for better yocto integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(aasdk CXX)
+set (AASDK_VERSION_MAJOR 2)
+set (AASDK_VERSION_MINOR 1)
+set (AASDK_VERSION_PATCH 0)
 
 set(base_directory ${CMAKE_CURRENT_SOURCE_DIR})
 set(sources_directory ${base_directory}/src)
@@ -70,6 +73,13 @@ target_link_libraries(aasdk libusb
                         ${OPENSSL_LIBRARIES}
                         ${WINSOCK2_LIBRARIES})
 
+set(AASDK_VERSION_STRING ${AASDK_VERSION_MAJOR}.${AASDK_VERSION_MINOR}.${AASDK_VERSION_PATCH})
+set_target_properties(aasdk PROPERTIES VERSION ${AASDK_VERSION_STRING}
+                                          SOVERSION ${AASDK_VERSION_MAJOR})
+
+INSTALL(TARGETS aasdk DESTINATION lib)
+
+		      
 if(AASDK_TEST)
     add_executable(aasdk_ut
                     ${tests_source_files}

--- a/aasdk_proto/CMakeLists.txt
+++ b/aasdk_proto/CMakeLists.txt
@@ -7,3 +7,9 @@ protobuf_generate_cpp(proto_sources proto_headers ${proto_files})
 add_library(aasdk_proto SHARED ${proto_headers} ${proto_sources})
 target_link_libraries(aasdk_proto ${PROTOBUF_LIBRARIES})
 
+set(AASDK_VERSION_STRING ${AASDK_VERSION_MAJOR}.${AASDK_VERSION_MINOR}.${AASDK_VERSION_PATCH})
+set_target_properties(aasdk_proto PROPERTIES VERSION ${AASDK_VERSION_STRING}
+                                          SOVERSION ${AASDK_VERSION_MAJOR})
+
+INSTALL(TARGETS aasdk_proto DESTINATION lib)
+					  

--- a/include/f1x/aasdk/IO/Promise.hpp
+++ b/include/f1x/aasdk/IO/Promise.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <functional>
+#include <boost/core/noncopyable.hpp>
 #include <boost/asio.hpp>
 #include <f1x/aasdk/Error/Error.hpp>
 #include <f1x/aasdk/IO/IOContextWrapper.hpp>


### PR DESCRIPTION
I am compiling openauto with in yocto. This patch allows for automated installation of the libraries into the right places with proper versioning.