### PR TITLE
Interleaved Message Handling and Frame Size handling in Decrypt

### DIFF
--- a/include/f1x/aasdk/Messenger/Cryptor.hpp
+++ b/include/f1x/aasdk/Messenger/Cryptor.hpp
@@ -38,7 +38,7 @@ public:
     void deinit() override;
     bool doHandshake() override;
     size_t encrypt(common::Data& output, const common::DataConstBuffer& buffer) override;
-    size_t decrypt(common::Data& output, const common::DataConstBuffer& buffer) override;
+    size_t decrypt(common::Data& output, const common::DataConstBuffer& buffer, int length) override;
 
     common::Data readHandshakeBuffer() override;
     void writeHandshakeBuffer(const common::DataConstBuffer& buffer) override;

--- a/include/f1x/aasdk/Messenger/FrameSize.hpp
+++ b/include/f1x/aasdk/Messenger/FrameSize.hpp
@@ -37,6 +37,7 @@ public:
 
     common::Data getData() const;
     size_t getSize() const;
+    size_t getTotalSize() const;
 
     static size_t getSizeOf(FrameSizeType type);
 

--- a/include/f1x/aasdk/Messenger/ICryptor.hpp
+++ b/include/f1x/aasdk/Messenger/ICryptor.hpp
@@ -40,7 +40,7 @@ public:
     virtual void deinit() = 0;
     virtual bool doHandshake() = 0;
     virtual size_t encrypt(common::Data& output, const common::DataConstBuffer& buffer) = 0;
-    virtual size_t decrypt(common::Data& output, const common::DataConstBuffer& buffer) = 0;
+    virtual size_t decrypt(common::Data& output, const common::DataConstBuffer& buffer, int length) = 0;
     virtual common::Data readHandshakeBuffer() = 0;
     virtual void writeHandshakeBuffer(const common::DataConstBuffer& buffer) = 0;
     virtual bool isActive() const = 0;

--- a/include/f1x/aasdk/Messenger/IMessageInStream.hpp
+++ b/include/f1x/aasdk/Messenger/IMessageInStream.hpp
@@ -37,6 +37,7 @@ public:
     virtual ~IMessageInStream() = default;
 
     virtual void startReceive(ReceivePromise::Pointer promise) = 0;
+    virtual void setInterleavedHandler(ReceivePromise::Pointer promise) = 0;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/MessageInStream.hpp
+++ b/include/f1x/aasdk/Messenger/MessageInStream.hpp
@@ -37,6 +37,7 @@ public:
     MessageInStream(boost::asio::io_service& ioService, transport::ITransport::Pointer transport, ICryptor::Pointer cryptor);
 
     void startReceive(ReceivePromise::Pointer promise) override;
+    void setInterleavedHandler(ReceivePromise::Pointer promise) override;
 
 private:
     using std::enable_shared_from_this<MessageInStream>::shared_from_this;
@@ -48,13 +49,21 @@ private:
     boost::asio::io_service::strand strand_;
     transport::ITransport::Pointer transport_;
     ICryptor::Pointer cryptor_;
-    FrameType recentFrameType_;
+    FrameType thisFrameType_;
     ReceivePromise::Pointer promise_;
+    ReceivePromise::Pointer interleavedPromise_;
     Message::Pointer message_;
     int frameSize_;
 
 
-    std::map<messenger::ChannelId, Message::Pointer> channel_assembly_buffers;
+    ChannelId currentChannelId_;
+    ChannelId originalMessageChannelId_;
+    std::map<messenger::ChannelId, Message::Pointer> messageBuffer_;
+
+
+    bool isInterleaved_;
+    bool haveOriginalChannel_;
+    bool isNewMessage_;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/MessageInStream.hpp
+++ b/include/f1x/aasdk/Messenger/MessageInStream.hpp
@@ -51,6 +51,8 @@ private:
     FrameType recentFrameType_;
     ReceivePromise::Pointer promise_;
     Message::Pointer message_;
+    int frameSize_;
+
 
     std::map<messenger::ChannelId, Message::Pointer> channel_assembly_buffers;
 };

--- a/include/f1x/aasdk/Messenger/Messenger.hpp
+++ b/include/f1x/aasdk/Messenger/Messenger.hpp
@@ -46,9 +46,11 @@ private:
     typedef std::list<std::pair<Message::Pointer, SendPromise::Pointer>> ChannelSendQueue;
     void doSend();
     void inStreamMessageHandler(Message::Pointer message);
+    void randomInStreamMessageHandler(Message::Pointer message);
     void outStreamMessageHandler(ChannelSendQueue::iterator queueElement);
     void rejectReceivePromiseQueue(const error::Error& e);
     void rejectSendPromiseQueue(const error::Error& e);
+    void randomRejectReceivePromiseQueue(const error::Error& e);
     void parseMessage(Message::Pointer message, ReceivePromise::Pointer promise);
 
     boost::asio::io_service::strand receiveStrand_;

--- a/src/Messenger/Cryptor.cpp
+++ b/src/Messenger/Cryptor.cpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <f1x/aasdk/Messenger/Cryptor.hpp>
 #include <f1x/aasdk/Error/Error.hpp>
+#include <f1x/aasdk/Common/Log.hpp>
 
 namespace f1x
 {
@@ -179,18 +180,23 @@ size_t Cryptor::encrypt(common::Data& output, const common::DataConstBuffer& buf
     return this->read(output);
 }
 
-size_t Cryptor::decrypt(common::Data& output, const common::DataConstBuffer& buffer)
+size_t Cryptor::decrypt(common::Data& output, const common::DataConstBuffer& buffer, int frameLength)
 {
+    int overhead = 29;
+    int length = frameLength - overhead;
     std::lock_guard<decltype(mutex_)> lock(mutex_);
 
     this->write(buffer);
     const size_t beginOffset = output.size();
-    output.resize(beginOffset + 1);
 
-    size_t availableBytes = 1;
-    size_t totalReadSize = 0;
+    size_t totalReadSize = 0;                                                                               // Initialise
+    size_t availableBytes = length;
+    size_t readBytes = (length - totalReadSize) > 2048 ? 2048 : length - totalReadSize;                     // Calculate How many Bytes to Read
+    output.resize(output.size() + readBytes);                                                               // Resize Output to match the bytes we want to read
 
-    while(availableBytes > 0)
+    // We try to be a bit more explicit here, using the frame length from the frame itself rather than just blindly reading from the SSL buffer.
+
+    while(readBytes > 0)
     {
         const auto& currentBuffer = common::DataBuffer(output, totalReadSize + beginOffset);
         auto readSize = sslWrapper_->sslRead(ssl_, currentBuffer.data, currentBuffer.size);
@@ -202,7 +208,8 @@ size_t Cryptor::decrypt(common::Data& output, const common::DataConstBuffer& buf
 
         totalReadSize += readSize;
         availableBytes = sslWrapper_->getAvailableBytes(ssl_);
-        output.resize(output.size() + availableBytes);
+        readBytes = (length - totalReadSize) > 2048 ? 2048 : length - totalReadSize;
+        output.resize(output.size() + readBytes);
     }
 
     return totalReadSize;

--- a/src/Messenger/FrameSize.cpp
+++ b/src/Messenger/FrameSize.cpp
@@ -48,6 +48,7 @@ FrameSize::FrameSize(const common::DataConstBuffer& buffer)
     {
         frameSizeType_ = FrameSizeType::SHORT;
         frameSize_ = boost::endian::big_to_native(reinterpret_cast<const uint16_t&>(buffer.cdata[0]));
+        totalSize_ = frameSize_;
     }
 
     if(buffer.size >= 6)

--- a/src/Messenger/MessageInStream.cpp
+++ b/src/Messenger/MessageInStream.cpp
@@ -122,6 +122,7 @@ void MessageInStream::receiveFrameSizeHandler(const common::DataConstBuffer& buf
         });
 
     FrameSize frameSize(buffer);
+    frameSize_ = (int) frameSize.getSize();
     transport_->receive(frameSize.getSize(), std::move(transportPromise));
 }
 
@@ -131,7 +132,7 @@ void MessageInStream::receiveFramePayloadHandler(const common::DataConstBuffer& 
     {
         try
         {
-            cryptor_->decrypt(message_->getPayload(), buffer);
+            cryptor_->decrypt(message_->getPayload(), buffer, frameSize_);
         }
         catch(const error::Error& e)
         {

--- a/src/Messenger/MessageInStream.cpp
+++ b/src/Messenger/MessageInStream.cpp
@@ -82,7 +82,7 @@ void MessageInStream::receiveFrameHeaderHandler(const common::DataConstBuffer& b
     // If Frame Channel does not match Message Channel, store Existing Message in Buffer.
     if(message_ != nullptr && message_->getChannelId() != frameHeader.getChannelId())
     {
-        AASDK_LOG(debug) << "[MessageInStream] ChannelId mismatch -- Frame " << channelIdToString(frameHeader_.getChannelId()) << " -- Message -- " << channelIdToString(message_.getChannelId());
+        AASDK_LOG(debug) << "[MessageInStream] ChannelId mismatch -- Frame " << channelIdToString(frameHeader.getChannelId()) << " -- Message -- " << channelIdToString(message_->getChannelId());
         isInterleaved_ = true;
 
         messageBuffer_[message_->getChannelId()] = message_;
@@ -186,11 +186,13 @@ void MessageInStream::receiveFramePayloadHandler(const common::DataConstBuffer& 
     {
         // If this isn't an interleaved frame, then we can resolve the promise
         if (!isInterleaved_) {
+            AASDK_LOG(debug) << "[MessageInStream] Resolving message.";
             isResolved = true;
             promise_->resolve(std::move(message_));
             promise_.reset();
         } else {
             // Otherwise resolve through our random promise
+            AASDK_LOG(debug) << "[MessageInStream] Resolving interleaved frame";
             interleavedPromise_->resolve(std::move(message_));
         }
     }

--- a/src/Transport/SSLWrapper.cpp
+++ b/src/Transport/SSLWrapper.cpp
@@ -22,6 +22,7 @@
 #include <openssl/ssl.h>
 #include <openssl/conf.h>
 #include <f1x/aasdk/Transport/SSLWrapper.hpp>
+#include <f1x/aasdk/Common/Log.hpp>
 
 namespace f1x
 {
@@ -49,6 +50,8 @@ SSLWrapper::~SSLWrapper()
     ERR_remove_state(0);
 #endif
     ERR_free_strings();
+    ERR_load_crypto_strings();
+    ERR_load_ERR_strings();
 }
 
 X509* SSLWrapper::readCertificate(const std::string& certificate)
@@ -188,6 +191,9 @@ int SSLWrapper::sslWrite(SSL *ssl, const void *buf, int num)
 
 int SSLWrapper::getError(SSL* ssl, int returnCode)
 {
+    while (auto err = ERR_get_error()) {
+        AASDK_LOG(error) << "[SSLWrapper] SSL Error " << ERR_error_string(err, NULL);
+    }
     return SSL_get_error(ssl, returnCode);
 }
 


### PR DESCRIPTION
Rework message handling.

Essentially, OpenAuto uses one Messenger between each service, but each service is running on a specific channel which is passed to messenger under enqueueReceive.

Promises are being used as Observables so when we find an interleaved frame, we're resolving a promise on a message for a different channel. Although the previous implementation worked, it didn't see well with the concept of promises.

What I have tried to implement here, is to ensure we only resolve the original message only and anything else we send back via an interleaved Frame Handler.

We probably need to look at what we do with the interleaved frame - as it needs to get back to the appropriate calling service. Perhaps we could make Messenger service aware and convert the promises to observables, so that Messenger can basically pass information directly into the appropriate Service by Channel Id rather than doing resolve()

also didn't like the Cryptor implementation that seemed to blindly read from the buffer regardless of Frame Size.

Added Frame Size handling to decrypt();