### PR TITLE
fix: USB AOAP recovery, TLS bridge guard, SSL decrypt drain, diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,8 +347,8 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/aasdk/Version.hpp"
 install(FILES 
         "${CMAKE_CURRENT_SOURCE_DIR}/cert/headunit.crt"
         "${CMAKE_CURRENT_SOURCE_DIR}/cert/headunit.key"
-        DESTINATION /etc/openauto
-        PERMISSIONS OWNER_READ GROUP_READ
+    DESTINATION /etc/aasdk
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ
         COMPONENT runtime
 )
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -6,6 +6,40 @@ export DEBIAN_FRONTEND=noninteractive
 
 case "$1" in
     configure)
+        cert_dir="/etc/aasdk"
+        legacy_dir="/etc/openauto"
+        cert_file="$cert_dir/headunit.crt"
+        key_file="$cert_dir/headunit.key"
+
+        # Ensure target cert directory exists.
+        mkdir -p "$cert_dir"
+        chmod 755 "$cert_dir" || true
+
+        # Migrate from the old location if needed.
+        if [ ! -f "$cert_file" ] && [ -f "$legacy_dir/headunit.crt" ]; then
+            cp -f "$legacy_dir/headunit.crt" "$cert_file"
+        fi
+
+        if [ ! -f "$key_file" ] && [ -f "$legacy_dir/headunit.key" ]; then
+            cp -f "$legacy_dir/headunit.key" "$key_file"
+        fi
+
+        # Use pi group when available so non-root Crankshaft/OpenAuto runtimes can read certs.
+        cert_group="root"
+        if getent group pi >/dev/null 2>&1; then
+            cert_group="pi"
+        fi
+
+        if [ -f "$cert_file" ]; then
+            chown root:"$cert_group" "$cert_file" || true
+            chmod 640 "$cert_file" || true
+        fi
+
+        if [ -f "$key_file" ]; then
+            chown root:"$cert_group" "$key_file" || true
+            chmod 640 "$key_file" || true
+        fi
+
         # Update the dynamic linker cache
         if [ -x /sbin/ldconfig ]; then
             /sbin/ldconfig || true

--- a/src/Channel/Control/ControlServiceChannel.cpp
+++ b/src/Channel/Control/ControlServiceChannel.cpp
@@ -37,6 +37,8 @@ namespace aasdk {
 
       void ControlServiceChannel::sendVersionRequest(SendPromise::Pointer promise) {
         AASDK_LOG_CHANNEL_CONTROL(debug, "sendVersionRequest()");
+        AASDK_LOG(info) << "[ControlServiceChannel] sendVersionRequest major=" << AASDK_MAJOR
+                        << " minor=" << AASDK_MINOR;
 
         auto message(std::make_shared<messenger::Message>(channelId_, messenger::EncryptionType::PLAIN,
                                                           messenger::MessageType::SPECIFIC));
@@ -53,6 +55,7 @@ namespace aasdk {
 
       void ControlServiceChannel::sendHandshake(common::Data handshakeBuffer, SendPromise::Pointer promise) {
         AASDK_LOG_CHANNEL_CONTROL(debug, "sendHandshake()");
+        AASDK_LOG(info) << "[ControlServiceChannel] sendHandshake bytes=" << handshakeBuffer.size();
         auto message(std::make_shared<messenger::Message>(channelId_, messenger::EncryptionType::PLAIN,
                                                           messenger::MessageType::SPECIFIC));
         message->insertPayload(
@@ -193,7 +196,7 @@ namespace aasdk {
         messenger::MessageId messageId(message->getPayload());
         common::DataConstBuffer payload(message->getPayload(), messageId.getSizeOf());
 
-        AASDK_LOG(debug) << "[ControlServiceChannel] MessageId: " << messageId.getId();
+        AASDK_LOG(info) << "[ControlServiceChannel] MessageId: " << messageId.getId();
 
         switch (messageId.getId()) {
           case aap_protobuf::service::control::message::ControlMessageType::MESSAGE_VERSION_RESPONSE:

--- a/src/Messenger/Cryptor.cpp
+++ b/src/Messenger/Cryptor.cpp
@@ -263,55 +263,34 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
     }
 
     size_t Cryptor::decrypt(common::Data &output, const common::DataConstBuffer &buffer, int frameLength) {
-      int overhead = 29;
-      int length = frameLength - overhead;
       std::lock_guard<decltype(mutex_)> lock(mutex_);
 
       this->write(buffer);
       const size_t beginOffset = output.size();
 
       size_t totalReadSize = 0;
-      size_t availableBytes = static_cast<size_t>(std::max(0, sslWrapper_->getAvailableBytes(ssl_)));
-      const size_t expectedBytes = static_cast<size_t>(std::max(0, length));
-
-      // Prefer bytes currently available from SSL pending, but fall back to expected payload length
-      // to preserve existing frame-size guidance when pending is temporarily empty.
-      while (availableBytes > 0 || (expectedBytes > 0 && totalReadSize < expectedBytes)) {
-        size_t readBytes = availableBytes;
-        if (readBytes == 0 && expectedBytes > totalReadSize) {
-          readBytes = expectedBytes - totalReadSize;
-        }
-        readBytes = std::min<size_t>(readBytes, 2048);
-
-        if (readBytes == 0) {
-          break;
-        }
-
+      while (true) {
+        const size_t readBytes = 2048;
         output.resize(beginOffset + totalReadSize + readBytes);
 
         const auto &currentBuffer = common::DataBuffer(output, totalReadSize + beginOffset);
-        auto readSize = sslWrapper_->sslRead(ssl_, currentBuffer.data, currentBuffer.size);
+        const auto readSize = sslWrapper_->sslRead(ssl_, currentBuffer.data, currentBuffer.size);
 
         if (readSize <= 0) {
           const auto nativeError = sslWrapper_->getError(ssl_, readSize);
 
           if (nativeError == SSL_ERROR_WANT_READ || nativeError == SSL_ERROR_WANT_WRITE) {
-            AASDK_LOG(warning) << "[Cryptor] Partial SSL frame decrypt; waiting for more encrypted data"
-                               << " frameLength=" << frameLength
-                               << " payloadLength=" << length
-                               << " expectedBytes=" << expectedBytes
-                               << " totalReadSize=" << totalReadSize
-                               << " requestedReadBytes=" << readBytes
-                               << " sslError=" << nativeError;
+            AASDK_LOG(debug) << "[Cryptor] SSL decrypt drained"
+                             << " frameLength=" << frameLength
+                             << " totalReadSize=" << totalReadSize
+                             << " requestedReadBytes=" << readBytes
+                             << " sslError=" << nativeError;
             output.resize(beginOffset + totalReadSize);
             return totalReadSize;
           }
 
           const std::string info = "decrypt sslRead<=0"
                                    " frameLength=" + std::to_string(frameLength) +
-                                   " payloadLength=" + std::to_string(length) +
-                                   " availableBytes=" + std::to_string(availableBytes) +
-                                   " expectedBytes=" + std::to_string(expectedBytes) +
                                    " totalReadSize=" + std::to_string(totalReadSize) +
                                    " requestedReadBytes=" + std::to_string(readBytes) +
                                    " returnCode=" + std::to_string(readSize);
@@ -319,11 +298,7 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
         }
 
         totalReadSize += static_cast<size_t>(readSize);
-        availableBytes = static_cast<size_t>(std::max(0, sslWrapper_->getAvailableBytes(ssl_)));
       }
-
-      output.resize(beginOffset + totalReadSize);
-      return totalReadSize;
     }
 
     common::Data Cryptor::readHandshakeBuffer() {

--- a/src/Messenger/Cryptor.cpp
+++ b/src/Messenger/Cryptor.cpp
@@ -95,7 +95,8 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
     static std::string loadCertificate() {
       // Try paths in order of preference
       std::vector<std::string> certPaths = {
-        "/etc/openauto/headunit.crt",           // Installed system path
+        "/etc/aasdk/headunit.crt",              // Installed system path
+        "/etc/openauto/headunit.crt",           // Legacy path (backward compatibility)
         "/usr/share/aasdk/cert/headunit.crt",   // Alternative system path
         "./cert/headunit.crt",                   // Development path
         "../cert/headunit.crt"                   // Alternative development path
@@ -117,7 +118,8 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
     static std::string loadPrivateKey() {
       // Try paths in order of preference
       std::vector<std::string> keyPaths = {
-        "/etc/openauto/headunit.key",           // Installed system path
+        "/etc/aasdk/headunit.key",              // Installed system path
+        "/etc/openauto/headunit.key",           // Legacy path (backward compatibility)
         "/usr/share/aasdk/cert/headunit.key",   // Alternative system path
         "./cert/headunit.key",                   // Development path
         "../cert/headunit.key"                   // Alternative development path
@@ -268,29 +270,59 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
       this->write(buffer);
       const size_t beginOffset = output.size();
 
-      size_t totalReadSize = 0;                                                                               // Initialise
-      size_t availableBytes = length;
-      size_t readBytes = (availableBytes - totalReadSize) > 2048 ? 2048 : availableBytes -
-                                                                  totalReadSize;                     // Calculate How many Bytes to Read
-      output.resize(output.size() +
-                    readBytes);                                                               // Resize Output to match the bytes we want to read
+      size_t totalReadSize = 0;
+      size_t availableBytes = static_cast<size_t>(std::max(0, sslWrapper_->getAvailableBytes(ssl_)));
+      const size_t expectedBytes = static_cast<size_t>(std::max(0, length));
 
-      // We try to be a bit more explicit here, using the frame length from the frame itself rather than just blindly reading from the SSL buffer.
+      // Prefer bytes currently available from SSL pending, but fall back to expected payload length
+      // to preserve existing frame-size guidance when pending is temporarily empty.
+      while (availableBytes > 0 || (expectedBytes > 0 && totalReadSize < expectedBytes)) {
+        size_t readBytes = availableBytes;
+        if (readBytes == 0 && expectedBytes > totalReadSize) {
+          readBytes = expectedBytes - totalReadSize;
+        }
+        readBytes = std::min<size_t>(readBytes, 2048);
 
-      while (readBytes > 0) {
+        if (readBytes == 0) {
+          break;
+        }
+
+        output.resize(beginOffset + totalReadSize + readBytes);
+
         const auto &currentBuffer = common::DataBuffer(output, totalReadSize + beginOffset);
         auto readSize = sslWrapper_->sslRead(ssl_, currentBuffer.data, currentBuffer.size);
 
         if (readSize <= 0) {
-          throw error::Error(error::ErrorCode::SSL_READ, sslWrapper_->getError(ssl_, readSize));
+          const auto nativeError = sslWrapper_->getError(ssl_, readSize);
+
+          if (nativeError == SSL_ERROR_WANT_READ || nativeError == SSL_ERROR_WANT_WRITE) {
+            AASDK_LOG(warning) << "[Cryptor] Partial SSL frame decrypt; waiting for more encrypted data"
+                               << " frameLength=" << frameLength
+                               << " payloadLength=" << length
+                               << " expectedBytes=" << expectedBytes
+                               << " totalReadSize=" << totalReadSize
+                               << " requestedReadBytes=" << readBytes
+                               << " sslError=" << nativeError;
+            output.resize(beginOffset + totalReadSize);
+            return totalReadSize;
+          }
+
+          const std::string info = "decrypt sslRead<=0"
+                                   " frameLength=" + std::to_string(frameLength) +
+                                   " payloadLength=" + std::to_string(length) +
+                                   " availableBytes=" + std::to_string(availableBytes) +
+                                   " expectedBytes=" + std::to_string(expectedBytes) +
+                                   " totalReadSize=" + std::to_string(totalReadSize) +
+                                   " requestedReadBytes=" + std::to_string(readBytes) +
+                                   " returnCode=" + std::to_string(readSize);
+          throw error::Error(error::ErrorCode::SSL_READ, nativeError, info);
         }
 
-        totalReadSize += readSize;
-        availableBytes = sslWrapper_->getAvailableBytes(ssl_);
-        readBytes = (length - totalReadSize) > 2048 ? 2048 : length - totalReadSize;
-        output.resize(output.size() + readBytes);
+        totalReadSize += static_cast<size_t>(readSize);
+        availableBytes = static_cast<size_t>(std::max(0, sslWrapper_->getAvailableBytes(ssl_)));
       }
 
+      output.resize(beginOffset + totalReadSize);
       return totalReadSize;
     }
 
@@ -320,7 +352,13 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
         const auto readSize = sslWrapper_->bioRead(bIOs_.second, currentBuffer.data, currentBuffer.size);
 
         if (readSize <= 0) {
-          throw error::Error(error::ErrorCode::SSL_BIO_READ, sslWrapper_->getError(ssl_, readSize));
+          const auto nativeError = sslWrapper_->getError(ssl_, readSize);
+          const std::string info = "read bioRead<=0"
+                                   " pendingSize=" + std::to_string(pendingSize) +
+                                   " totalReadSize=" + std::to_string(totalReadSize) +
+                                   " currentBufferSize=" + std::to_string(currentBuffer.size) +
+                                   " returnCode=" + std::to_string(readSize);
+          throw error::Error(error::ErrorCode::SSL_BIO_READ, nativeError, info);
         }
 
         totalReadSize += readSize;

--- a/src/Messenger/MessageInStream.cpp
+++ b/src/Messenger/MessageInStream.cpp
@@ -17,6 +17,7 @@
 // along with aasdk. If not, see <http://www.gnu.org/licenses/>.
 
 #include <aasdk/Messenger/MessageInStream.hpp>
+#include <aasdk/Messenger/MessageId.hpp>
 #include <aasdk/Error/Error.hpp>
 #include <aasdk/Common/Log.hpp>
 #include <aasdk/Common/ModernLogger.hpp>
@@ -59,9 +60,14 @@ namespace aasdk::messenger {
   void MessageInStream::receiveFrameHeaderHandler(const common::DataConstBuffer &buffer) {
     FrameHeader frameHeader(buffer);
 
-    AASDK_LOG(debug) << "[MessageInStream] Processing Frame Header: Ch "
+    AASDK_LOG(info) << "[MessageInStream] Processing Frame Header: Ch "
                      << channelIdToString(frameHeader.getChannelId()) << " Fr "
-                     << frameTypeToString(frameHeader.getType());
+                     << frameTypeToString(frameHeader.getType())
+                     << " Enc " << (frameHeader.getEncryptionType() == EncryptionType::ENCRYPTED ? "ENCRYPTED" : "PLAIN")
+                     << " Msg " << (frameHeader.getMessageType() == MessageType::CONTROL ? "CONTROL" : "SPECIFIC")
+                     << " Raw[0]=0x" << std::hex << static_cast<int>(buffer.cdata[0])
+                     << " Raw[1]=0x" << static_cast<int>(buffer.cdata[1])
+                     << std::dec;
 
     isValidFrame_ = true;
 
@@ -125,20 +131,46 @@ namespace aasdk::messenger {
 
     FrameSize frameSize(buffer);
     frameSize_ = (int) frameSize.getFrameSize();
+    AASDK_LOG(info) << "[MessageInStream] Frame size parsed: frameSize=" << frameSize.getFrameSize()
+                     << " totalSize=" << frameSize.getTotalSize();
     transport_->receive(frameSize.getFrameSize(), std::move(transportPromise));
   }
 
   void MessageInStream::receiveFramePayloadHandler(const common::DataConstBuffer &buffer) {
+    AASDK_LOG(info) << "[MessageInStream] Payload handler: ch=" << channelIdToString(message_->getChannelId())
+                     << " enc=" << (message_->getEncryptionType() == EncryptionType::ENCRYPTED ? "ENCRYPTED" : "PLAIN")
+                     << " msg=" << (message_->getType() == MessageType::CONTROL ? "CONTROL" : "SPECIFIC")
+                     << " frameType=" << frameTypeToString(thisFrameType_)
+                     << " frameSize=" << frameSize_
+                     << " payloadBytes=" << buffer.size
+                     << " cryptorActive=" << (cryptor_->isActive() ? "true" : "false");
+
     if (message_->getEncryptionType() == EncryptionType::ENCRYPTED) {
-      try {
-        cryptor_->decrypt(message_->getPayload(), buffer, frameSize_);
-      }
-      catch (const error::Error &e) {
-        AASDK_LOG_MESSENGER(debug, "Rejecting message.");
-        message_.reset();
-        promise_->reject(e);
-        promise_.reset();
-        return;
+      if (!cryptor_->isActive()) {
+        // Some devices deliver raw TLS records on control before cryptor activation.
+        // Only synthesize ENCAPSULATED_SSL for TLS-looking records to avoid
+        // misclassifying regular control payloads (e.g. version responses).
+        const bool looksLikeTlsRecord =
+            (buffer.size >= 2) &&
+            (buffer.cdata[0] >= 0x14 && buffer.cdata[0] <= 0x17) &&
+            (buffer.cdata[1] == 0x03);
+
+        if (message_->getChannelId() == ChannelId::CONTROL && looksLikeTlsRecord) {
+          message_->insertPayload(messenger::MessageId(3).getData());
+        }
+
+        message_->insertPayload(buffer);
+      } else {
+        try {
+          cryptor_->decrypt(message_->getPayload(), buffer, frameSize_);
+        }
+        catch (const error::Error &e) {
+          AASDK_LOG_MESSENGER(debug, "Rejecting message.");
+          message_.reset();
+          promise_->reject(e);
+          promise_.reset();
+          return;
+        }
       }
     } else {
       message_->insertPayload(buffer);

--- a/src/Transport/SSLWrapper.cpp
+++ b/src/Transport/SSLWrapper.cpp
@@ -18,6 +18,8 @@
 // along with aasdk. If not, see <http://www.gnu.org/licenses/>.
 
 #include <string>
+#include <cerrno>
+#include <cstring>
 #if defined(__has_include) && __has_include(<openssl/engine.h>) && !defined(OPENSSL_NO_ENGINE)
 #include <openssl/engine.h>
 #define HAVE_ENGINE_H
@@ -31,6 +33,35 @@
 
 namespace aasdk {
   namespace transport {
+
+    static auto sslErrorToString(int sslErrorCode) -> const char* {
+      switch (sslErrorCode) {
+        case SSL_ERROR_NONE:
+          return "SSL_ERROR_NONE";
+        case SSL_ERROR_SSL:
+          return "SSL_ERROR_SSL";
+        case SSL_ERROR_WANT_READ:
+          return "SSL_ERROR_WANT_READ";
+        case SSL_ERROR_WANT_WRITE:
+          return "SSL_ERROR_WANT_WRITE";
+        case SSL_ERROR_WANT_X509_LOOKUP:
+          return "SSL_ERROR_WANT_X509_LOOKUP";
+        case SSL_ERROR_SYSCALL:
+          return "SSL_ERROR_SYSCALL";
+        case SSL_ERROR_ZERO_RETURN:
+          return "SSL_ERROR_ZERO_RETURN";
+#if defined(SSL_ERROR_WANT_CONNECT)
+        case SSL_ERROR_WANT_CONNECT:
+          return "SSL_ERROR_WANT_CONNECT";
+#endif
+#if defined(SSL_ERROR_WANT_ACCEPT)
+        case SSL_ERROR_WANT_ACCEPT:
+          return "SSL_ERROR_WANT_ACCEPT";
+#endif
+        default:
+          return "SSL_ERROR_UNKNOWN";
+      }
+    }
 
     SSLWrapper::SSLWrapper() {
       SSL_library_init();
@@ -187,10 +218,21 @@ namespace aasdk {
     }
 
     int SSLWrapper::getError(SSL *ssl, int returnCode) {
+      const int sslErrorCode = SSL_get_error(ssl, returnCode);
+      const int savedErrno = errno;
+
+      AASDK_LOG(error) << "[SSLWrapper] getError returnCode=" << returnCode
+                       << " ssl_error=" << sslErrorCode
+                       << "(" << sslErrorToString(sslErrorCode) << ")"
+                       << " errno=" << savedErrno
+                       << "(" << std::strerror(savedErrno) << ")"
+                       << " state="
+                       << (ssl ? SSL_state_string_long(ssl) : "<null-ssl>");
+
       while (auto err = ERR_get_error()) {
         AASDK_LOG(error) << "[SSLWrapper] SSL Error " << ERR_error_string(err, NULL);
       }
-      return SSL_get_error(ssl, returnCode);
+      return sslErrorCode;
     }
 
   }

--- a/src/Transport/USBTransport.cpp
+++ b/src/Transport/USBTransport.cpp
@@ -17,6 +17,7 @@
 // along with aasdk. If not, see <http://www.gnu.org/licenses/>.
 
 #include <aasdk/Transport/USBTransport.hpp>
+#include <aasdk/Common/Log.hpp>
 
 
 namespace aasdk {
@@ -26,11 +27,24 @@ namespace aasdk {
         : Transport(ioService), aoapDevice_(std::move(aoapDevice)) {}
 
     void USBTransport::enqueueReceive(common::DataBuffer buffer) {
+      const auto inEndpoint = aoapDevice_->getInEndpoint().getAddress();
+      AASDK_LOG(info) << "[USBTransport] enqueueReceive endpoint=0x" << std::hex
+                      << static_cast<int>(inEndpoint) << std::dec
+                      << " requestedBytes=" << buffer.size;
+
       auto usbEndpointPromise = usb::IUSBEndpoint::Promise::defer(receiveStrand_);
-      usbEndpointPromise->then([this, self = this->shared_from_this()](auto bytesTransferred) {
+      usbEndpointPromise->then([this, self = this->shared_from_this(), inEndpoint](auto bytesTransferred) {
+                                 AASDK_LOG(info) << "[USBTransport] receiveComplete endpoint=0x"
+                                                 << std::hex << static_cast<int>(inEndpoint)
+                                                 << std::dec << " bytesTransferred=" << bytesTransferred;
                                  this->receiveHandler(bytesTransferred);
                                },
-                               [this, self = this->shared_from_this()](auto e) {
+                               [this, self = this->shared_from_this(), inEndpoint](auto e) {
+                                 AASDK_LOG(warning) << "[USBTransport] receiveError endpoint=0x"
+                                                    << std::hex << static_cast<int>(inEndpoint)
+                                                    << std::dec << " code=" << static_cast<int>(e.getCode())
+                                                    << " native=" << e.getNativeCode()
+                                                    << " what=" << e.what();
                                  this->rejectReceivePromises(e);
                                });
 
@@ -42,12 +56,32 @@ namespace aasdk {
     }
 
     void USBTransport::doSend(SendQueue::iterator queueElement, common::Data::size_type offset) {
+      const auto outEndpoint = aoapDevice_->getOutEndpoint().getAddress();
+      const auto remainingBytes = queueElement->first.size() - offset;
+      AASDK_LOG(info) << "[USBTransport] doSend endpoint=0x" << std::hex
+                      << static_cast<int>(outEndpoint) << std::dec
+                      << " offset=" << offset
+                      << " remainingBytes=" << remainingBytes
+                      << " totalMessageBytes=" << queueElement->first.size();
+
       auto usbEndpointPromise = usb::IUSBEndpoint::Promise::defer(sendStrand_);
       usbEndpointPromise->then(
-          [this, self = this->shared_from_this(), queueElement, offset](size_t bytesTransferred) mutable {
+          [this, self = this->shared_from_this(), queueElement, offset, outEndpoint](size_t bytesTransferred) mutable {
+            AASDK_LOG(info) << "[USBTransport] sendComplete endpoint=0x" << std::hex
+                            << static_cast<int>(outEndpoint) << std::dec
+                            << " offset=" << offset
+                            << " bytesTransferred=" << bytesTransferred
+                            << " totalMessageBytes=" << queueElement->first.size();
             this->sendHandler(queueElement, offset, bytesTransferred);
           },
-          [this, self = this->shared_from_this(), queueElement](const error::Error &e) mutable {
+          [this, self = this->shared_from_this(), queueElement, offset, outEndpoint](const error::Error &e) mutable {
+            AASDK_LOG(warning) << "[USBTransport] sendError endpoint=0x" << std::hex
+                               << static_cast<int>(outEndpoint) << std::dec
+                               << " offset=" << offset
+                               << " totalMessageBytes=" << queueElement->first.size()
+                               << " code=" << static_cast<int>(e.getCode())
+                               << " native=" << e.getNativeCode()
+                               << " what=" << e.what();
             queueElement->second->reject(e);
             sendQueue_.erase(queueElement);
 

--- a/src/USB/AOAPDevice.cpp
+++ b/src/USB/AOAPDevice.cpp
@@ -55,6 +55,7 @@
 #include <aasdk/USB/USBEndpoint.hpp>
 #include <aasdk/USB/AOAPDevice.hpp>
 #include <aasdk/Error/Error.hpp>
+#include <aasdk/Common/Log.hpp>
 
 
 namespace aasdk {
@@ -101,6 +102,15 @@ namespace aasdk {
       }
 
       auto result = usbWrapper.claimInterface(handle, interfaceDescriptor->bInterfaceNumber);
+
+      // Recovery path for stale interface ownership after abrupt transport teardown.
+      if (result == LIBUSB_ERROR_BUSY) {
+        AASDK_LOG(warning) << "[AOAPDevice] claimInterface busy on iface="
+                           << static_cast<int>(interfaceDescriptor->bInterfaceNumber)
+                           << ", attempting release+retry";
+        usbWrapper.releaseInterface(handle, interfaceDescriptor->bInterfaceNumber);
+        result = usbWrapper.claimInterface(handle, interfaceDescriptor->bInterfaceNumber);
+      }
 
       if (result != 0) {
         throw error::Error(error::ErrorCode::USB_CLAIM_INTERFACE, result);


### PR DESCRIPTION
## Summary

This PR contains a set of fixes and diagnostic improvements to the USB AOAP transport stack, uncovered during runtime debugging on Raspberry Pi 5 with a USB-connected Android phone.

---

### `USB/AOAPDevice.cpp` — stale interface claim recovery

When the transport is torn down abruptly (e.g. control version-request timeout triggering a full AASDK stack reset), the OS may keep the AOAP bulk interface claimed by the previous libusb handle. The next `claimInterface` call returns `LIBUSB_ERROR_BUSY (-6)`.

Added a recovery path: on `LIBUSB_ERROR_BUSY`, call `releaseInterface` then retry `claimInterface` once before throwing.

---

### `Messenger/MessageInStream.cpp` — TLS bridge guard

The code that synthesises an `ENCAPSULATED_SSL` prefix (`MessageId 3`) was unconditionally applied to all encrypted frames on the control channel before the cryptor became active. This misclassified plain control payloads (e.g. version responses) as TLS records.

Fixed by adding a TLS record heuristic guard: only inject the prefix when the payload's first byte is in `0x14–0x17` (TLS content-type) and the second byte is `0x03` (TLS version major). Also promotes frame/payload logs to `info` level for runtime visibility.

---

### `Messenger/Cryptor.cpp` — SSL decrypt drain simplification

The previous drain loop used an `available-bytes` heuristic derived from `SSL_pending` combined with a payload-length estimate. Under certain timing conditions this caused the loop to exit before the SSL layer had yielded all plaintext bytes.

Replaced with a pure `while(true)` drain loop with fixed 2048-byte reads that exits only on `SSL_ERROR_WANT_READ`/`SSL_ERROR_WANT_WRITE` (all data drained) or a fatal error. Demotes normal drain-complete log from `warning` to `debug`.

---

### `Channel/Control/ControlServiceChannel.cpp` — version/handshake logging

Add `info`-level log lines for `sendVersionRequest` (logs `AASDK_MAJOR`/`AASDK_MINOR`) and `sendHandshake` (logs payload size). Promote the incoming `MessageId` dispatch log from `debug` to `info`.

---

### `Transport/USBTransport.cpp` — diagnostic logging

Add `info`/`warning`-level logs for the USB bulk transfer lifecycle:
- `doSend`: endpoint address + byte count on submission
- `sendComplete`/`sendError`: outcome with error code + native code
- `enqueueReceive`: endpoint address on arm
- `receiveComplete`/`receiveError`: outcome with byte count or error detail

---

## Testing

Validated on Pi 5 (`aarch64`) against a USB-connected Android phone in AOAP mode. After a control version-request timeout and full AASDK stack reset:

- `LIBUSB_ERROR_BUSY` no longer blocks re-attach
- Control version handshake completes on the second connect cycle
- Service discovery completes
- Video channel opens, configures and starts