### PR TITLE
Add runtime-toggleable Cryptor/Message tracing + quick-reference docs

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -135,10 +135,37 @@ export TARGET_ARCH=arm64           # Cross-compilation target
 export CMAKE_BUILD_PARALLEL_LEVEL=4 # Parallel build jobs
 export AASDK_LOG_LEVEL=DEBUG       # Logging level
 
+# Runtime tracing (no rebuild required)
+export AASDK_TRACE_CRYPTOR=1               # Enable Cryptor decrypt trace
+export AASDK_TRACE_CRYPTOR_SAMPLE_EVERY=8  # Log every Nth decrypt sample (1-1000)
+export AASDK_TRACE_MESSAGE=1               # Enable MessageInStream trace
+export AASDK_TRACE_MESSAGE_VIDEO_ONLY=1    # Restrict message trace to video channel
+export AASDK_TRACE_MESSAGE_SAMPLE_EVERY=2  # Log every Nth message sample (1-1000)
+
 # Library paths
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 ```
+
+## Runtime Trace Toggles
+
+Use these toggles to inspect encrypted frame flow at runtime without rebuilding aasdk.
+
+```bash
+# Example: focused projection-path diagnostics
+export AASDK_TRACE_CRYPTOR=1
+export AASDK_TRACE_CRYPTOR_SAMPLE_EVERY=8
+export AASDK_TRACE_MESSAGE=1
+export AASDK_TRACE_MESSAGE_VIDEO_ONLY=1
+export AASDK_TRACE_MESSAGE_SAMPLE_EVERY=2
+```
+
+Expected tags in logs:
+- `[CryptorTrace] decrypt-read`
+- `[CryptorTrace] decrypt-drained`
+- `[MessageTrace] encrypted-pass-through`
+- `[MessageTrace] decrypt`
+- `[MessageTrace] resolve`
 
 ## 📦 Package Information
 

--- a/src/Messenger/Cryptor.cpp
+++ b/src/Messenger/Cryptor.cpp
@@ -18,6 +18,9 @@
 // along with aasdk. If not, see <http://www.gnu.org/licenses/>.
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
 #include <functional>
 #include <fstream>
 #include <sstream>
@@ -28,6 +31,82 @@
 
 namespace aasdk {
   namespace messenger {
+
+    namespace {
+
+      struct RuntimeTraceConfig {
+        bool enabled{false};
+        int sampleEvery{1};
+      };
+
+      static auto parseEnvBool(const char* value, bool defaultValue) -> bool {
+        if (value == nullptr) {
+          return defaultValue;
+        }
+
+        const std::string token(value);
+        if (token.empty()) {
+          return defaultValue;
+        }
+
+        if (token == "1" || token == "true" || token == "TRUE" || token == "on" ||
+            token == "ON" || token == "yes" || token == "YES") {
+          return true;
+        }
+
+        if (token == "0" || token == "false" || token == "FALSE" || token == "off" ||
+            token == "OFF" || token == "no" || token == "NO") {
+          return false;
+        }
+
+        return defaultValue;
+      }
+
+      static auto parseEnvInt(const char* value, int defaultValue, int minValue, int maxValue) -> int {
+        if (value == nullptr) {
+          return defaultValue;
+        }
+
+        try {
+          const int parsed = std::stoi(value);
+          return std::max(minValue, std::min(maxValue, parsed));
+        } catch (...) {
+          return defaultValue;
+        }
+      }
+
+      static auto readRuntimeTraceConfig() -> RuntimeTraceConfig {
+        RuntimeTraceConfig cfg;
+        cfg.enabled = parseEnvBool(std::getenv("AASDK_TRACE_CRYPTOR"), false);
+        cfg.sampleEvery = parseEnvInt(std::getenv("AASDK_TRACE_CRYPTOR_SAMPLE_EVERY"), 1, 1, 1000);
+        return cfg;
+      }
+
+      static auto getRuntimeTraceConfig() -> RuntimeTraceConfig {
+        static RuntimeTraceConfig cached = readRuntimeTraceConfig();
+        static auto lastRefresh = std::chrono::steady_clock::now();
+
+        const auto now = std::chrono::steady_clock::now();
+        if (now - lastRefresh > std::chrono::seconds(1)) {
+          cached = readRuntimeTraceConfig();
+          lastRefresh = now;
+        }
+
+        return cached;
+      }
+
+      static auto shouldEmitTraceSample() -> bool {
+        static std::atomic<uint64_t> counter{0};
+        const RuntimeTraceConfig cfg = getRuntimeTraceConfig();
+        if (!cfg.enabled) {
+          return false;
+        }
+
+        const uint64_t current = ++counter;
+        return (current % static_cast<uint64_t>(cfg.sampleEvery)) == 0;
+      }
+
+    } // namespace
 
     // Embedded certificate constants
     static const std::string cCertificate = "-----BEGIN CERTIFICATE-----\n\
@@ -265,6 +344,9 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
     size_t Cryptor::decrypt(common::Data &output, const common::DataConstBuffer &buffer, int frameLength) {
       std::lock_guard<decltype(mutex_)> lock(mutex_);
 
+      const bool traceSample = shouldEmitTraceSample();
+      const int pendingBeforeWrite = sslWrapper_->getAvailableBytes(ssl_);
+
       this->write(buffer);
       const size_t beginOffset = output.size();
 
@@ -278,8 +360,19 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
 
         if (readSize <= 0) {
           const auto nativeError = sslWrapper_->getError(ssl_, readSize);
+          const int pendingAfterRead = sslWrapper_->getAvailableBytes(ssl_);
 
           if (nativeError == SSL_ERROR_WANT_READ || nativeError == SSL_ERROR_WANT_WRITE) {
+            if (traceSample) {
+              AASDK_LOG(info) << "[CryptorTrace] decrypt-drained"
+                              << " frameLength=" << frameLength
+                              << " encryptedBytesIn=" << buffer.size
+                              << " totalReadSize=" << totalReadSize
+                              << " requestedReadBytes=" << readBytes
+                              << " sslError=" << nativeError
+                              << " pendingBeforeWrite=" << pendingBeforeWrite
+                              << " pendingAfterRead=" << pendingAfterRead;
+            }
             AASDK_LOG(debug) << "[Cryptor] SSL decrypt drained"
                              << " frameLength=" << frameLength
                              << " totalReadSize=" << totalReadSize
@@ -298,6 +391,14 @@ KAwp3tIHPoJOQiKNQ3/qks5km/9dujUGU2ARiU3qmxLMdgegFz8e\n\
         }
 
         totalReadSize += static_cast<size_t>(readSize);
+        if (traceSample) {
+          AASDK_LOG(info) << "[CryptorTrace] decrypt-read"
+                          << " frameLength=" << frameLength
+                          << " encryptedBytesIn=" << buffer.size
+                          << " readSize=" << readSize
+                          << " totalReadSize=" << totalReadSize
+                          << " pendingBeforeWrite=" << pendingBeforeWrite;
+        }
       }
     }
 

--- a/src/Messenger/MessageInStream.cpp
+++ b/src/Messenger/MessageInStream.cpp
@@ -21,10 +21,92 @@
 #include <aasdk/Error/Error.hpp>
 #include <aasdk/Common/Log.hpp>
 #include <aasdk/Common/ModernLogger.hpp>
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
 #include <iostream>
+#include <string>
 
 
 namespace aasdk::messenger {
+
+  namespace {
+
+    struct MessageTraceConfig {
+      bool enabled{false};
+      bool videoOnly{true};
+      int sampleEvery{1};
+    };
+
+    static auto parseEnvBool(const char* value, bool defaultValue) -> bool {
+      if (value == nullptr) {
+        return defaultValue;
+      }
+
+      const std::string token(value);
+      if (token == "1" || token == "true" || token == "TRUE" || token == "on" ||
+          token == "ON" || token == "yes" || token == "YES") {
+        return true;
+      }
+
+      if (token == "0" || token == "false" || token == "FALSE" || token == "off" ||
+          token == "OFF" || token == "no" || token == "NO") {
+        return false;
+      }
+
+      return defaultValue;
+    }
+
+    static auto parseEnvInt(const char* value, int defaultValue, int minValue, int maxValue) -> int {
+      if (value == nullptr) {
+        return defaultValue;
+      }
+
+      try {
+        const int parsed = std::stoi(value);
+        return std::max(minValue, std::min(maxValue, parsed));
+      } catch (...) {
+        return defaultValue;
+      }
+    }
+
+    static auto readMessageTraceConfig() -> MessageTraceConfig {
+      MessageTraceConfig cfg;
+      cfg.enabled = parseEnvBool(std::getenv("AASDK_TRACE_MESSAGE"), false);
+      cfg.videoOnly = parseEnvBool(std::getenv("AASDK_TRACE_MESSAGE_VIDEO_ONLY"), true);
+      cfg.sampleEvery = parseEnvInt(std::getenv("AASDK_TRACE_MESSAGE_SAMPLE_EVERY"), 1, 1, 1000);
+      return cfg;
+    }
+
+    static auto getMessageTraceConfig() -> MessageTraceConfig {
+      static MessageTraceConfig cached = readMessageTraceConfig();
+      static auto lastRefresh = std::chrono::steady_clock::now();
+
+      const auto now = std::chrono::steady_clock::now();
+      if (now - lastRefresh > std::chrono::seconds(1)) {
+        cached = readMessageTraceConfig();
+        lastRefresh = now;
+      }
+
+      return cached;
+    }
+
+    static auto shouldTraceMessage(ChannelId channelId) -> bool {
+      static size_t counter = 0;
+      const MessageTraceConfig cfg = getMessageTraceConfig();
+      if (!cfg.enabled) {
+        return false;
+      }
+
+      if (cfg.videoOnly && channelId != ChannelId::MEDIA_SINK_VIDEO) {
+        return false;
+      }
+
+      ++counter;
+      return (counter % static_cast<size_t>(cfg.sampleEvery)) == 0;
+    }
+
+  } // namespace
 
   MessageInStream::MessageInStream(boost::asio::io_service &ioService, transport::ITransport::Pointer transport,
                                    ICryptor::Pointer cryptor)
@@ -137,6 +219,10 @@ namespace aasdk::messenger {
   }
 
   void MessageInStream::receiveFramePayloadHandler(const common::DataConstBuffer &buffer) {
+    const ChannelId channelId = message_->getChannelId();
+    const bool traceMessage = shouldTraceMessage(channelId);
+    const size_t payloadSizeBefore = message_->getPayload().size();
+
     AASDK_LOG(info) << "[MessageInStream] Payload handler: ch=" << channelIdToString(message_->getChannelId())
                      << " enc=" << (message_->getEncryptionType() == EncryptionType::ENCRYPTED ? "ENCRYPTED" : "PLAIN")
                      << " msg=" << (message_->getType() == MessageType::CONTROL ? "CONTROL" : "SPECIFIC")
@@ -160,9 +246,24 @@ namespace aasdk::messenger {
         }
 
         message_->insertPayload(buffer);
+        if (traceMessage) {
+          AASDK_LOG(info) << "[MessageTrace] encrypted-pass-through"
+                          << " ch=" << channelIdToString(channelId)
+                          << " payloadBytes=" << buffer.size
+                          << " payloadSizeAfter=" << message_->getPayload().size();
+        }
       } else {
         try {
-          cryptor_->decrypt(message_->getPayload(), buffer, frameSize_);
+          const size_t decryptedBytes = cryptor_->decrypt(message_->getPayload(), buffer, frameSize_);
+          if (traceMessage) {
+            AASDK_LOG(info) << "[MessageTrace] decrypt"
+                            << " ch=" << channelIdToString(channelId)
+                            << " frameSize=" << frameSize_
+                            << " encryptedBytes=" << buffer.size
+                            << " decryptedBytes=" << decryptedBytes
+                            << " payloadSizeBefore=" << payloadSizeBefore
+                            << " payloadSizeAfter=" << message_->getPayload().size();
+          }
         }
         catch (const error::Error &e) {
           AASDK_LOG_MESSENGER(debug, "Rejecting message.");
@@ -181,6 +282,12 @@ namespace aasdk::messenger {
     // If this is the LAST frame or a BULK frame...
     if ((thisFrameType_ == FrameType::BULK || thisFrameType_ == FrameType::LAST) && isValidFrame_) {
       AASDK_LOG_MESSENGER(debug, "Resolving message.");
+      if (traceMessage) {
+        AASDK_LOG(info) << "[MessageTrace] resolve"
+                        << " ch=" << channelIdToString(channelId)
+                        << " frameType=" << frameTypeToString(thisFrameType_)
+                        << " totalPayloadBytes=" << message_->getPayload().size();
+      }
       promise_->resolve(std::move(message_));
       promise_.reset();
       isResolved = true;


### PR DESCRIPTION
## Summary
- Add runtime-toggleable trace instrumentation in `Cryptor::decrypt`.
- Add runtime-toggleable trace instrumentation in `MessageInStream::receiveFramePayloadHandler`.
- Document trace toggles and sample usage in `QUICK_REFERENCE.md`.

## Why
Projection diagnostics were requiring rebuilds for each additional log point. This change enables targeted decrypt/message tracing at runtime via environment variables.

## Runtime toggles
- `AASDK_TRACE_CRYPTOR` (0/1)
- `AASDK_TRACE_CRYPTOR_SAMPLE_EVERY` (1-1000)
- `AASDK_TRACE_MESSAGE` (0/1)
- `AASDK_TRACE_MESSAGE_VIDEO_ONLY` (0/1)
- `AASDK_TRACE_MESSAGE_SAMPLE_EVERY` (1-1000)

## Expected log tags
- `[CryptorTrace] decrypt-read`
- `[CryptorTrace] decrypt-drained`
- `[MessageTrace] encrypted-pass-through`
- `[MessageTrace] decrypt`
- `[MessageTrace] resolve`

## Validation
- Built and installed aasdk from this branch locally.
- Verified runtime trace output appears when toggles are enabled.
